### PR TITLE
removed support for 'skill' in manifest.nlu

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,16 +18,13 @@ require('dotenv').config();
 if(manifest.nlu.indexOf('wcs') > -1) {
     handler.initialize();
 }
-let newManifest = JSON.parse(JSON.stringify(manifest));
-//in case the nlu is handled in the skill - create nlu engines
-let index = newManifest.nlu.indexOf('skill');
-newManifest.nlu.splice(index, 1);
-if(index > -1) {
-    if(newManifest.nlu.length < 1) {
-        console.log('No Nlu engines selected, you need to add the nlu engines you want to use to manifest.nlu (along with "skill") ')
-    }
-    else {
-        factory.getNLUs(newManifest).then(updatedManifest => {
+if(manifest.nlu.indexOf('skill') !== -1) {
+    console.error('Please remove skill from the manifest\'s nlu field, skill evaluation is the default option');
+} else {
+    if (manifest.nlu.length < 1) {
+        console.error('No Nlu engines selected, you need to add the nlu engines you want to use to manifest.nlu')
+    } else {
+        factory.getNLUs(manifest).then(updatedManifest => {
             if (updatedManifest.nlu.regexp) {
                 updatedManifest.intents = require('./res/nlu/intents');
             }

--- a/index.js
+++ b/index.js
@@ -21,20 +21,19 @@ if(manifest.nlu.indexOf('wcs') > -1) {
 let index = manifest.nlu.indexOf('skill');
 if(index !== -1) {
     manifest.nlu.splice(index, 1);
+}
+if (manifest.nlu.length < 1) {
+    console.error('No Nlu engines selected, you need to add the nlu engines you want to use to manifest.json nlu field')
 } else {
-    if (manifest.nlu.length < 1) {
-        console.error('No Nlu engines selected, you need to add the nlu engines you want to use to manifest.json nlu field')
-    } else {
-        factory.getNLUs(manifest).then(updatedManifest => {
-            if (updatedManifest.nlu.regexp) {
-                updatedManifest.intents = require('./res/nlu/intents');
-            }
-            handler.manifest = updatedManifest;
-            factory.createAll(updatedManifest).then(function (engines) {
-                handler.engines = engines;
-            });
+    factory.getNLUs(manifest).then(updatedManifest => {
+        if (updatedManifest.nlu.regexp) {
+            updatedManifest.intents = require('./res/nlu/intents');
+        }
+        handler.manifest = updatedManifest;
+        factory.createAll(updatedManifest).then(function (engines) {
+            handler.engines = engines;
         });
-    }
+    });
 }
 
 // The expertise handler

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ if(manifest.nlu.indexOf('skill') !== -1) {
     console.error('Please remove skill from the manifest\'s nlu field, skill evaluation is the default option');
 } else {
     if (manifest.nlu.length < 1) {
-        console.error('No Nlu engines selected, you need to add the nlu engines you want to use to manifest.nlu')
+        console.error('No Nlu engines selected, you need to add the nlu engines you want to use to manifest.json nlu field')
     } else {
         factory.getNLUs(manifest).then(updatedManifest => {
             if (updatedManifest.nlu.regexp) {

--- a/index.js
+++ b/index.js
@@ -18,8 +18,9 @@ require('dotenv').config();
 if(manifest.nlu.indexOf('wcs') > -1) {
     handler.initialize();
 }
-if(manifest.nlu.indexOf('skill') !== -1) {
-    console.error('Please remove skill from the manifest\'s nlu field, skill evaluation is the default option');
+let index = manifest.nlu.indexOf('skill');
+if(index !== -1) {
+    manifest.nlu.splice(index, 1);
 } else {
     if (manifest.nlu.length < 1) {
         console.error('No Nlu engines selected, you need to add the nlu engines you want to use to manifest.json nlu field')

--- a/res/assets/manifest.json
+++ b/res/assets/manifest.json
@@ -9,7 +9,7 @@
     "en-US"
   ],
   "nlu": [
-    "regexp", "wcs", "skill"
+    "regexp", "wcs"
   ],
   "tags": [
     "hello world"

--- a/res/assets/manifest.json
+++ b/res/assets/manifest.json
@@ -9,7 +9,7 @@
     "en-US"
   ],
   "nlu": [
-    "skill", "regexp"
+    "regexp"
   ],
   "tags": [
     "hello world"

--- a/res/assets/manifest.json
+++ b/res/assets/manifest.json
@@ -9,7 +9,7 @@
     "en-US"
   ],
   "nlu": [
-    "regexp", "wcs"
+    "wcs", "regexp", "skill"
   ],
   "tags": [
     "hello world"

--- a/res/assets/manifest.json
+++ b/res/assets/manifest.json
@@ -9,7 +9,7 @@
     "en-US"
   ],
   "nlu": [
-    "regexp"
+    "regexp", "wcs", "skill"
   ],
   "tags": [
     "hello world"


### PR DESCRIPTION
removed checks for 'skill' as one of the nlu engines (added an error in case it's still there).
Tested manually seems to work fine.

git issue: https://github.ibm.com/ConsumerIoT/WA-dev-issues/issues/324
